### PR TITLE
fix: remove radxa-system-config-disable-sleep in task-qcs6490

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,6 @@ Package: task-qcs6490
 Architecture: all
 Priority: optional
 Depends: task-qualcomm,
-         radxa-system-config-disable-sleep,
          ${misc:Depends},
 Description: Metapackages for common Qualcomm QCS6490 vendor packages
  This package provides prebuilt packages from Qualcomm QCS6490 that


### PR DESCRIPTION
Radxa Dragon Q6A supports suspend in Linux 6.17.1

https://applink.feishu.cn/client/message/link/open?token=AmfHwOsK4gAEaO83JmmKAAM%3D

This reverts commit d10465acc42010597536a52ebecca99dfb5fc583.

https://github.com/radxa-pkg/linux-qcom/pull/9 needs to be merged first.