### PR TITLE
feat: add cp-dsp-firmware hook

### DIFF
--- a/debian/task-qcs6490.install
+++ b/debian/task-qcs6490.install
@@ -1,0 +1,1 @@
+task-qcs6490/usr /

--- a/task-qcs6490/usr/share/initramfs-tools/hooks/zz-cp-dsp-firmware
+++ b/task-qcs6490/usr/share/initramfs-tools/hooks/zz-cp-dsp-firmware
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+PREREQ=""
+
+prereqs()
+{
+    echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+mkdir -p ${DESTDIR}/lib/firmware/qcom/qcs6490/radxa
+cp -r /lib/firmware/qcom/qcs6490/radxa/* ${DESTDIR}/lib/firmware/qcom/qcs6490/radxa


### PR DESCRIPTION
在 update-initramfs 触发后, 安装 ko 到 initramfs 会调用 dracut-install, dracut 的代码中有个函数 find_suppliers_for_sys_node 会扫描 /sys/devices/platform 下路径，在安装模块 pinctrl-sc7280-lpass-lpi 触发操作可以看到 remoteproc 下的 qcom_q6v5_pas.ko 也会被带上。调试源代码 pinctrl_sc7280_lpass_lpi 传入之后搜到 fts_path 路径 /sys/devices/platform/soc@0/33c0000.pinctrl/modalias，node_path 路径为 /sys/devices/platform/soc@0/33c0000.pinctrl 下面存在 supplier:platform:3700000.remoteproc, 最终导致安装 remoteproc 相关的模块带上, 由于 NPU 使用需要 cdsp, initramfs 中没有 cdsp 相关的固件导致在开机阶段加载失败，后续开机无法正常使用 NPU 功能, 这里直接将相关固件直接拷贝到 initramfs, 后续内核更新后也可以正常使用 NPU.