### PR TITLE
feat: add deps for task-qualcomm

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends: qcom-iot-defaults,
          task-qualcomm-gstreamer,
          radxa-system-config-qualcomm,
          task-qualcomm-npu,
+         vulkan-tools,
          ${misc:Depends},
 Description: Metapackages for common Qualcomm vendor packages
  This package provides prebuilt packages from Qualcomm that


### PR DESCRIPTION
使用开源 GPU 驱动的 Radxa OS, 都默认安装 vulkan 组件.
详情查看内部 https://redmine.vamrs.org/issues/4038