### PR TITLE
feat: divert zzz-update-dtb kernel hook from dragonwing-defaults

### DIFF
--- a/debian/task-qualcomm.postrm
+++ b/debian/task-qualcomm.postrm
@@ -7,6 +7,7 @@ case $1 in
     remove)
         conflicts="
         /usr/lib/modprobe.d/blacklist-qcom-camera.conf
+        /etc/kernel/postinst.d/zzz-update-dtb
         "
         for i in $conflicts
         do

--- a/debian/task-qualcomm.preinst
+++ b/debian/task-qualcomm.preinst
@@ -5,6 +5,7 @@ case $1 in
     install|upgrade|triggered)
         conflicts="
         /usr/lib/modprobe.d/blacklist-qcom-camera.conf
+        /etc/kernel/postinst.d/zzz-update-dtb
         "
         for i in $conflicts
         do


### PR DESCRIPTION
qcom-iot-defaults upgraded and pulled in dragonwing-defaults, which installs /etc/kernel/postinst.d/zzz-update-dtb. This hook is not needed in RadxaOS, so divert it in task-qualcomm.