### PR TITLE
feat: lower default microphone software volume

### DIFF
--- a/task-sc8280xp/usr/share/wireplumber/wireplumber.conf.d/99-lower-mic-default.conf
+++ b/task-sc8280xp/usr/share/wireplumber/wireplumber.conf.d/99-lower-mic-default.conf
@@ -1,0 +1,5 @@
+wireplumber.settings = {
+  device.routes.default-source-volume = {
+    default = 0.5
+  }
+}


### PR DESCRIPTION
WirePlumber defaults device.routes.default-source-volume to 1.0, making the headset mic start at max software gain. Combined with the wide ADC2 analog gain range (0-30dB), this causes noticeable noise in recordings. Lower the default to 0.5.