### PR TITLE
feat: set default source volume to 1.0 for headset mic ADC2

### DIFF
--- a/debian/task-qcs6490.install
+++ b/debian/task-qcs6490.install
@@ -1,0 +1,1 @@
+task-qcs6490/usr /

--- a/task-qcs6490/usr/share/wireplumber/wireplumber.conf.d/99-adc2-default.conf
+++ b/task-qcs6490/usr/share/wireplumber/wireplumber.conf.d/99-adc2-default.conf
@@ -1,0 +1,3 @@
+wireplumber.settings = {
+  device.routes.default-source-volume = 1.0
+}


### PR DESCRIPTION
WirePlumber 0.5.x (Debian 13, Ubuntu 26) syncs CaptureMixerElem to hardware on route activation. Without this config, software source volume defaults to 0.00 and gets written to ADC2 hardware, silencing the headset microphone.

WP 0.4.x (Ubuntu 24) does not sync on activation, so this config is harmless there but also not needed.

Verified on Debian 13 (WP 0.5.8) and Ubuntu 26 (WP 0.5.13).