### PR TITLE
fix: disable systemd TTYReset to prevent serial hang on

### DIFF
--- a/debian/task-qualcomm.install
+++ b/debian/task-qualcomm.install
@@ -4,3 +4,4 @@ task-qualcomm/common/systemd/no-prestart.conf /usr/lib/systemd/system/cdsprpcd.s
 task-qualcomm/common/systemd/no-prestart.conf /usr/lib/systemd/system/cdsp1rpcd.service.d
 task-qualcomm/common/systemd/no-prestart.conf /usr/lib/systemd/system/gdsprpcd.service.d
 task-qualcomm/common/systemd/no-prestart.conf /usr/lib/systemd/system/gdsp1rpcd.service.d
+task-qualcomm/usr/lib/systemd/system/serial-getty@.service.d/99-noreset.conf /usr/lib/systemd/system/serial-getty@.service.d/

--- a/task-qualcomm/usr/lib/systemd/system/serial-getty@.service.d/99-noreset.conf
+++ b/task-qualcomm/usr/lib/systemd/system/serial-getty@.service.d/99-noreset.conf
@@ -1,0 +1,3 @@
+[Service]
+TTYReset=no
+TTYVHangup=no


### PR DESCRIPTION
Ubuntu 26 ships systemd 259 which changed TTYReset from reset_terminal_fd() to terminal_reset_defensive(), adding tcflush(TCIOFLUSH) + vhangup + ANSI sequences. When kernel console (console=ttyMSM0) is active during boot, this races with the GENI UART driver's console_write path, corrupting the engine state and blocking all serial output after ~4s.

Serial stops at boot, login prompt never appears. Disconnecting/reconnecting serial software recovers it. System boots fine (SSH works), TX pin stays at 1.8V (hardware OK, software issue).

Fix: Set TTYReset=no and TTYVHangup=no to avoid touching the UART while the kernel console is active.

TODO: Fix qcom_geni_serial driver to properly handle console/FIFO mode transitions during tcflush/vhangup at boot time.